### PR TITLE
Fix parsing /proc/cmdline

### DIFF
--- a/secure-boot
+++ b/secure-boot
@@ -30,6 +30,10 @@ ifdef EFIBOOTDEVICE
 EFIBOOTMGR += -d $(EFIBOOTDEVICE)
 endif
 
+ifeq (,$(wildcard $(CMDLINE)))
+CMDLINE := /proc/cmdline
+endif
+
 .PHONY: default clean update install
 
 default:
@@ -49,9 +53,7 @@ $(BOOTDIR)/${DESTFILE}: $(BUILDDIR)/combined-boot-signed.efi
 
 $(BUILDDIR)/cmdline.txt:
 	@mkdir -p $(BUILDDIR)
-	[ -f ${CMDLINE} ] && \
-	    tr '\n' ' ' < ${CMDLINE} > $@ || \
-	    echo -n `</proc/cmdline` > $@
+	tr '\n' ' ' < ${CMDLINE} > $@
 
 $(BUILDDIR)/initramfs.img: $(UCODE) $(INITRAMFS)
 	@mkdir -p $(BUILDDIR)


### PR DESCRIPTION
The current syntax in master for copying `/proc/cmdline` doesn't work in POSIX shell and leaves cmdline empty and system unbootable. I didn't see a reason to treat `/proc/cmdline` and `/etc/kernel/cmdline` differently when extracting cmdline, so I refactored a little to use the same code.

What do you think?